### PR TITLE
[Feat]: 상세 페이지, 목록 페이지 컨트롤러 작성

### DIFF
--- a/src/controllers/trialController.js
+++ b/src/controllers/trialController.js
@@ -2,16 +2,24 @@ const { statusCode, responseMessage } = require('../globals');
 const { resFormatter } = require('../utils');
 const trialService = require('../services/trialService.js');
 const logger = require('../utils/logger');
-const { ValidationError } = require('../utils/errors/commonError');
-
+const { ValidationError, EntityNotExistError } = require('../utils/errors/commonError');
 
 // 상세 페이지 API
 module.exports.getTrialDetail = async (req, res, next) => {
   try {
     const { trialId } = req.params;
+    
     if (trialId === undefined)
       throw new ValidationError();
 
+    const trial = await trialService.readTrial(trialId);
+   
+    if (!trial)
+      throw new EntityNotExistError();
+
+    return res
+      .status(statusCode.OK)
+      .send(resFormatter.success(responseMessage.READ_SUCCESS, trial));
   } catch (err) {
     next(err);
   }
@@ -21,16 +29,20 @@ module.exports.getTrialDetail = async (req, res, next) => {
 // 리스트 페이지 API
 module.exports.getTrials = async (req, res, next) => {
   try {
-    const { page, limit } = req.query;
-
-    if (page === undefined || limit === undefined)
-      throw new ValidationError();
-
+    const { page = 1, limit = 10 } = req.query;
+    const data = {
+      page,
+      limit
+    };
+    const trials = await trialService.readTrialList(data);
+    
+    return res
+      .status(statusCode.OK)
+      .send(resFormatter.success(responseMessage.LIST_SUCCESS, trials));
   } catch (err) {
     next(err);
   }
 }
-
 
 // 검색 API
 module.exports.searchTrials = async (req, res, next) => {

--- a/src/globals/responseMessage.js
+++ b/src/globals/responseMessage.js
@@ -12,5 +12,7 @@ module.exports = {
   ENTITY_NOT_EXIST: "DB에 없는 데이터 관련 요청입니다.",
   NO_PAGE_ERROR: "해당 라우트는 존재하지 않습니다.",
 
-  
+  // trial
+  READ_SUCCESS: '과제 읽기 성공',
+  LIST_SUCCESS: '과제 목록'
 };


### PR DESCRIPTION
## 작업사항
1. 상세 페이지 컨트롤러에서 trialId를 db에 넘겨 과제를 받아와 리턴한다.
2. 목록 페이지 컨트롤러에서 page와 limit(default 존재)를 db에 넘겨 과제
   목록을 받아와 리턴한다.



## 관계된 이슈, PR 
#2 #3 