### PR TITLE
[feat]: 상세 페이지, 목록 페이지 서비스 작성

### DIFF
--- a/src/globals/routes.js
+++ b/src/globals/routes.js
@@ -4,8 +4,7 @@
 const ROOT = '/';
 
 const TRIAL = '/trials';
-const TRIAL_DETAIL = '/:trialId';
-
+const TRIAL_DETAIL = '/detail/:trialId';
 const SEARCH = '/search';
 
 

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -4,11 +4,12 @@ const logger = require('../utils/logger');
 const fs = require('fs');
 const path = require('path');
 const basename = path.basename(__filename);
+// const Op = Sequelize.Op;
 
-const IS_SQLLITE = configs.db.isSqlite;
-
+const IS_SQLLITE = false;
 
 let sequelize;
+
 if (IS_SQLLITE) {
   sequelize = new Sequelize({
     dialect: 'sqlite',

--- a/src/services/trialService.js
+++ b/src/services/trialService.js
@@ -2,15 +2,22 @@ const models = require('../models');
 const { InternalServerError } = require('http-errors');
 const { EntityNotExistError, ValidationError } = require('../utils/errors/commonError');
 const logger = require('../utils/logger');
-const logTag = 'src:transaction';
+const trial = require('../models/trial');
+const { sequelize } = require('../models');
+const Op = sequelize.Op;
 
 /**
  * 상세조회
  * data.trialId
  */
-exports.readTrial = async (data)=>{
+exports.readTrial = async (trialId)=>{
   try{
-
+    const trial = await models.trial.findOne({
+      where: {
+        id: trialId
+      }
+    })
+    return trial
   }catch(err){
     throw err;
   }
@@ -23,7 +30,12 @@ exports.readTrial = async (data)=>{
  */
 exports.readTrialList = async (data)=>{
   try{
-
+    const trials = await models.trial.findAll({
+      offset: data.page,
+      limit: data.limit,
+      order: [['createdAt', 'DESC']]
+    })
+    return trials
   }catch(err){
     throw err;
   }
@@ -39,7 +51,20 @@ exports.readTrialList = async (data)=>{
  */
 exports.searchTrials = async (data)=>{
   try{
-
+    const searchTrials = await models.trial.findAll({
+      where: {
+        name: {
+          [Op.like]: `%${data.name}%`
+        },
+        type: {
+          [Op.like]: `%${data.type}%`
+        },
+        department: {
+          [Op.like]: `%${data.department}%`
+        }
+      }
+    })
+    return searchTrials;
   }catch(err){
     throw err;
   }
@@ -47,7 +72,7 @@ exports.searchTrials = async (data)=>{
 
 /**
  * 생성 혹은 변경
- * data = [{
+ * data = {
  *          '과제명': 'Lymphoma Study for Auto-PBSCT',
  *          '과제번호': 'C100002',
  *          '연구기간': '1년',
@@ -58,9 +83,7 @@ exports.searchTrials = async (data)=>{
  *          '전체목표연구대상자수': '',
  *          '진료과': 'Hematology',
  *           hash: '3449c9e5e332f1dbb81505cd739fbf3f'
- *        }, 
- *        ...,
- *       ]  
+ *        }
  */
 exports.createOrUpdateTrials= async (data)=>{
   try{
@@ -68,4 +91,5 @@ exports.createOrUpdateTrials= async (data)=>{
   }catch(err){
     throw err;
   }
+	
 }


### PR DESCRIPTION
## 작업사항
1. 상세 페이지 컨트롤러에서 trialId를 받아서 DB에서 trialId와 일치하는 값을 찾고 컨트롤러로 전달
2. 목록 페이지 컨트롤러에서 page와 limit을 받아서 DB에서 값을 찾고 컨트롤러로 전달
3. 검색 기능은 sequelize의 Op 디펜던시 추가 후 작업 예정

## 관계된 이슈, PR 